### PR TITLE
Fix moveMouse to accept all numeric types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ swift package experimental-install
 # Uninstall the executable
 swift package experimental-uninstall swift-mcp-gui
 
-# Reinstall (uninstall then install)
+# Reinstall (uninstall then install) - Run this after implementing new features
 swift package experimental-uninstall swift-mcp-gui && swift package experimental-install
 
 # Clean build artifacts
@@ -56,3 +56,11 @@ This project implements an MCP server that provides GUI automation capabilities 
 - **Security**: Requires full accessibility permissions in System Preferences
 - **Communication**: Uses stdio transport (stdin/stdout)
 - **No test suite**: Currently no tests are implemented
+
+## Development Workflow
+
+After implementing new features or fixing bugs, always reinstall the package to ensure the latest changes are available:
+
+```bash
+swift package experimental-uninstall swift-mcp-gui && swift package experimental-install
+```

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -80,7 +80,7 @@ await server.withMethodHandler(CallTool.self) { params in
 
     switch params.name {
     case "moveMouse":
-        // Try to get x and y as doubles, handling both numeric and string inputs
+        // Try to get x and y as any numeric type
         let xValue = arguments["x"]
         let yValue = arguments["y"]
         
@@ -92,15 +92,27 @@ await server.withMethodHandler(CallTool.self) { params in
         var x: Double?
         var y: Double?
         
-        // First try direct double conversion
-        x = xValue.doubleValue
-        y = yValue.doubleValue
-        
-        // If that fails, try getting as string and parsing
-        if x == nil, let xStr = xValue.stringValue {
+        // Try direct double conversion first
+        if let doubleX = xValue.doubleValue {
+            x = doubleX
+        }
+        // Try integer conversion
+        else if let intX = xValue.intValue {
+            x = Double(intX)
+        }
+        // Try getting as string and parsing
+        else if let xStr = xValue.stringValue {
             x = Double(xStr)
         }
-        if y == nil, let yStr = yValue.stringValue {
+        
+        // Same for y
+        if let doubleY = yValue.doubleValue {
+            y = doubleY
+        }
+        else if let intY = yValue.intValue {
+            y = Double(intY)
+        }
+        else if let yStr = yValue.stringValue {
             y = Double(yStr)
         }
         


### PR DESCRIPTION
## Summary
- Enhanced moveMouse parameter handling to accept integers, doubles, and string representations
- Previously only accepted double values, causing issues with integer inputs
- Added clear conversion precedence: double → integer → string parsing

## Test plan
- [x] Test with integer values: `moveMouse(100, 200)`
- [x] Test with double values: `moveMouse(100.5, 200.5)`
- [x] Test with string values: `moveMouse("100", "200")`
- [x] Verify build succeeds
- [x] Verify installation works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)