### PR TITLE
Update dependencies: swift-sdk 0.12.0, SwiftAutoGUI 0.19.0, macOS 26

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "563bfb558ed9a5796a0fc0c7e16b4e3fbdd257fb93f9798aae49083da222232b",
+  "originHash" : "9ae1cb628abd1168dd99b40eac1fab463eaa900da908de730e22fe66dde0569b",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "ca2a9d90cbe49e09b92f4b6ebd922c03ebea51d0",
-        "version" : "1.3.0"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -20,12 +20,12 @@
       }
     },
     {
-      "identity" : "swift-async-algorithms",
+      "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
-        "version" : "1.9.1"
+        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
+        "version" : "1.11.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
-        "version" : "2.96.0"
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "6112a3995a992d159ad0e82c2d62a008ce932666",
-        "version" : "0.11.0"
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NakaokaRei/SwiftAutoGUI.git",
       "state" : {
-        "revision" : "bde107712d4f951011012ba466558d4736e490ce",
-        "version" : "0.13.0"
+        "revision" : "dde59283d270356d04bf17142e0da9332843b8de",
+        "version" : "0.19.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,11 +6,11 @@ import PackageDescription
 let package = Package(
     name: "swift-mcp-gui",
     platforms: [
-        .macOS(.v15)
+        .macOS(.v26)
     ],
     dependencies: [
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.9.0"),
-        .package(url: "https://github.com/NakaokaRei/SwiftAutoGUI.git", from: "0.10.0")
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
+        .package(url: "https://github.com/NakaokaRei/SwiftAutoGUI.git", from: "0.17.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/swift-mcp-gui/Tools/Screen/CaptureRegionTool.swift
+++ b/Sources/swift-mcp-gui/Tools/Screen/CaptureRegionTool.swift
@@ -59,7 +59,7 @@ struct CaptureRegionTool {
             
             let region = CGRect(x: x, y: y, width: width, height: height)
             
-            guard let screenshot = SwiftAutoGUI.screenshot(region: region) else {
+            guard let screenshot = try? await SwiftAutoGUI.screenshot(region: region) else {
                 return .init(content: [.text("Failed to capture screen region")], isError: true)
             }
             

--- a/Sources/swift-mcp-gui/Tools/Screen/CaptureScreenTool.swift
+++ b/Sources/swift-mcp-gui/Tools/Screen/CaptureScreenTool.swift
@@ -34,7 +34,7 @@ struct CaptureScreenTool {
             let scale = (try? parser.parseDouble("scale")) ?? 0.25
             let output = (try? parser.parseString("output")) ?? "path"
             
-            guard let screenshot = SwiftAutoGUI.screenshot() else {
+            guard let screenshot = try? await SwiftAutoGUI.screenshot() else {
                 return .init(content: [.text("Failed to capture screen")], isError: true)
             }
             

--- a/Sources/swift-mcp-gui/Tools/Screen/GetPixelColorTool.swift
+++ b/Sources/swift-mcp-gui/Tools/Screen/GetPixelColorTool.swift
@@ -24,7 +24,7 @@ struct GetPixelColorTool {
                 let x = try parser.parseInt("x")
                 let y = try parser.parseInt("y")
                 
-                guard let color = SwiftAutoGUI.pixel(x: x, y: y) else {
+                guard let color = try? await SwiftAutoGUI.pixel(x: x, y: y) else {
                     return .init(content: [.text("Failed to get pixel color at (\(x), \(y))")], isError: true)
                 }
                 

--- a/Sources/swift-mcp-gui/Tools/Screen/SaveScreenshotTool.swift
+++ b/Sources/swift-mcp-gui/Tools/Screen/SaveScreenshotTool.swift
@@ -62,9 +62,9 @@ struct SaveScreenshotTool {
                 let screenshot: NSImage?
                 if let x = x, let y = y, let width = width, let height = height {
                     let region = CGRect(x: x, y: y, width: width, height: height)
-                    screenshot = SwiftAutoGUI.screenshot(region: region)
+                    screenshot = try? await SwiftAutoGUI.screenshot(region: region)
                 } else {
-                    screenshot = SwiftAutoGUI.screenshot()
+                    screenshot = try? await SwiftAutoGUI.screenshot()
                 }
                 
                 guard let image = screenshot else {

--- a/Tests/swift-mcp-guiTests/Tools/AppleScriptToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/AppleScriptToolsTests.swift
@@ -47,7 +47,7 @@ struct AppleScriptToolsTests {
         
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("AppleScript Result:") || text.contains("AppleScript executed successfully")
                 }
                 return false
@@ -69,7 +69,7 @@ struct AppleScriptToolsTests {
         
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     // The result should contain "4" or similar
                     return text.contains("AppleScript Result:") || text.contains("no result returned")
                 }
@@ -90,7 +90,7 @@ struct AppleScriptToolsTests {
         // Note: This test might succeed or fail depending on AppleScript permissions
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("no result returned") || text.contains("AppleScript Result:")
                 }
                 return false
@@ -105,7 +105,7 @@ struct AppleScriptToolsTests {
         let result = try await toolRegistry.execute(name: "executeAppleScript", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: script")
             }
             return false
@@ -121,7 +121,7 @@ struct AppleScriptToolsTests {
         let result = try await toolRegistry.execute(name: "executeAppleScript", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Invalid parameter script: expected string")
             }
             return false
@@ -135,7 +135,7 @@ struct AppleScriptToolsTests {
         let result = try await toolRegistry.execute(name: "executeAppleScriptFile", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: path")
             }
             return false
@@ -151,7 +151,7 @@ struct AppleScriptToolsTests {
         let result = try await toolRegistry.execute(name: "executeAppleScriptFile", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Invalid parameter path: expected string")
             }
             return false
@@ -167,7 +167,7 @@ struct AppleScriptToolsTests {
         let result = try await toolRegistry.execute(name: "executeAppleScriptFile", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Failed to execute AppleScript file")
             }
             return false

--- a/Tests/swift-mcp-guiTests/Tools/KeyboardToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/KeyboardToolsTests.swift
@@ -20,7 +20,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: cmd+c"
             }
             return false
@@ -36,7 +36,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: space"
             }
             return false
@@ -52,7 +52,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: cmd+shift+a"
             }
             return false
@@ -77,7 +77,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: \(displayName)"
             }
             return false
@@ -93,7 +93,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("No keys specified")
             }
             return false
@@ -107,7 +107,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: keys")
             }
             return false
@@ -123,7 +123,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Unknown key: invalid_key")
             }
             return false
@@ -139,7 +139,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Invalid parameter keys")
             }
             return false
@@ -157,7 +157,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: \(key)"
             }
             return false
@@ -175,7 +175,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: \(key)"
             }
             return false
@@ -193,7 +193,7 @@ struct KeyboardToolsTests {
         let result = try await toolRegistry.execute(name: "sendKeys", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Sent key combination: \(key)"
             }
             return false

--- a/Tests/swift-mcp-guiTests/Tools/MouseToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/MouseToolsTests.swift
@@ -22,7 +22,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "moveMouse", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Mouse moved to (100.0, 200.0)"
             }
             return false
@@ -39,7 +39,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "moveMouse", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Mouse moved to (100.5, 200.7)"
             }
             return false
@@ -56,7 +56,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "moveMouse", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Mouse moved to (100.0, 200.0)"
             }
             return false
@@ -73,7 +73,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "moveMouse", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: y")
             }
             return false
@@ -89,7 +89,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "mouseClick", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "left click performed"
             }
             return false
@@ -105,7 +105,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "mouseClick", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "right click performed"
             }
             return false
@@ -121,7 +121,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "mouseClick", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Invalid button type")
             }
             return false
@@ -135,7 +135,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "unknownTool", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Unknown tool")
             }
             return false
@@ -153,7 +153,7 @@ struct MouseToolsTests {
         let result = try await toolRegistry.execute(name: "mouseClick", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "\(expected) click performed"
             }
             return false

--- a/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
@@ -26,7 +26,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "scroll", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Scrolled up by 3 clicks"
             }
             return false
@@ -45,7 +45,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "scroll", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Scrolled \(direction) by 2 clicks"
             }
             return false
@@ -62,7 +62,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "scroll", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Invalid scroll direction")
             }
             return false
@@ -78,7 +78,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "scroll", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: direction")
             }
             return false
@@ -94,7 +94,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "scroll", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: clicks")
             }
             return false
@@ -111,7 +111,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "scroll", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text == "Scrolled down by 5 clicks"
             }
             return false
@@ -125,7 +125,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "getScreenSize", arguments: arguments)
         #expect(result.isError == false)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Screen size:") && 
                        text.contains("width") && 
                        text.contains("height")
@@ -146,7 +146,7 @@ struct ScreenToolsTests {
         // In CI/CD environments, it might fail due to lack of screen access
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("Pixel color at (100, 200):") &&
                            text.contains("red") &&
                            text.contains("green") &&
@@ -168,7 +168,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "getPixelColor", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: y")
             }
             return false
@@ -186,7 +186,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("Pixel color at (50, 100):")
                 }
                 return false
@@ -205,7 +205,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("Pixel color at (50, 100):")
                 }
                 return false
@@ -221,7 +221,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access permissions
         if result.isError != true {
             #expect(result.content.first {
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("\"path\":") &&
                            text.contains("\"width\":") &&
                            text.contains("\"height\":")
@@ -241,7 +241,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access permissions
         if result.isError != true {
             #expect(result.content.first {
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("\"path\":") &&
                            text.contains("\"width\":") &&
                            text.contains("\"height\":")
@@ -280,7 +280,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access permissions
         if result.isError != true {
             #expect(result.content.first {
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("\"path\":") &&
                            text.contains("\"width\":") &&
                            text.contains("\"height\":")
@@ -301,7 +301,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "captureRegion", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: width")
             }
             return false
@@ -318,7 +318,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access permissions
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("\"success\": true") &&
                            text.contains("\"filename\": \"test_screenshot.png\"")
                 }
@@ -341,7 +341,7 @@ struct ScreenToolsTests {
         // This might succeed or fail depending on screen access permissions
         if result.isError != true {
             #expect(result.content.first { 
-                if case .text(let text) = $0 {
+                if case .text(let text, _, _) = $0 {
                     return text.contains("\"success\": true") &&
                            text.contains("\"filename\": \"test_region_screenshot.png\"")
                 }
@@ -360,7 +360,7 @@ struct ScreenToolsTests {
         let result = try await toolRegistry.execute(name: "saveScreenshot", arguments: arguments)
         #expect(result.isError == true)
         #expect(result.content.first { 
-            if case .text(let text) = $0 {
+            if case .text(let text, _, _) = $0 {
                 return text.contains("Missing parameter: filename")
             }
             return false


### PR DESCRIPTION
- Bump swift-tools-version from 6.0 to 6.2
- Bump platform requirement from macOS 15 to macOS 26
- Bump swift-sdk from 0.9.0 to 0.12.0
- Bump SwiftAutoGUI from 0.10.0 to 0.17.0+ (resolved to 0.19.0)
- Update source code for async/throwing SwiftAutoGUI APIs
- Update tests for new MCP SDK tuple-based .text enum case