### PR TITLE
Add getScreenContext tool

### DIFF
--- a/Sources/swift-mcp-gui/Tools/Screen/GetScreenContextTool.swift
+++ b/Sources/swift-mcp-gui/Tools/Screen/GetScreenContextTool.swift
@@ -1,0 +1,77 @@
+import Foundation
+import MCP
+import SwiftAutoGUI
+
+struct GetScreenContextTool {
+    static func register(in registry: ToolRegistry) {
+        let tool = Tool(
+            name: "getScreenContext",
+            description:
+                "Get rich context about the current screen state including frontmost app, visible windows, and accessibility tree of the focused window. Useful for understanding what is currently displayed on screen.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "maxDepth": .object([
+                        "type": .string("integer"),
+                        "description": .string(
+                            "Maximum depth of accessibility tree traversal (default: 5)"),
+                    ]),
+                    "maxNodes": .object([
+                        "type": .string("integer"),
+                        "description": .string(
+                            "Maximum number of accessibility nodes to collect (default: 200)"),
+                    ]),
+                    "maxValueLength": .object([
+                        "type": .string("integer"),
+                        "description": .string(
+                            "Maximum length for element values before truncation (default: 100)"),
+                    ]),
+                    "includeAXTree": .object([
+                        "type": .string("boolean"),
+                        "description": .string(
+                            "Whether to include the accessibility tree (default: true)"),
+                    ]),
+                    "format": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Output format: 'text' (default, LLM-friendly) or 'json' (structured)"),
+                        "enum": .array([.string("text"), .string("json")]),
+                    ]),
+                ]),
+            ])
+        )
+
+        registry.registerTool(definition: tool) { arguments in
+            let parser = ParameterParser(arguments: arguments)
+
+            let maxDepth = (try? parser.parseInt("maxDepth")) ?? 5
+            let maxNodes = (try? parser.parseInt("maxNodes")) ?? 200
+            let maxValueLength = (try? parser.parseInt("maxValueLength")) ?? 100
+            let includeAXTree = (try? parser.parseBool("includeAXTree")) ?? true
+            let format = (try? parser.parseString("format")) ?? "text"
+
+            let options = ScreenContextProvider.Options(
+                maxDepth: maxDepth,
+                maxNodes: maxNodes,
+                maxValueLength: maxValueLength,
+                includeAXTree: includeAXTree
+            )
+
+            let context = await MainActor.run {
+                ScreenContextProvider.gather(options: options)
+            }
+
+            let output: String
+            if format == "json" {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let data = try encoder.encode(context)
+                output = String(data: data, encoding: .utf8) ?? "{}"
+            } else {
+                output = context.formatted()
+            }
+
+            return .init(content: [.text(output)], isError: false)
+        }
+    }
+}

--- a/Sources/swift-mcp-gui/Tools/ToolRegistry.swift
+++ b/Sources/swift-mcp-gui/Tools/ToolRegistry.swift
@@ -35,5 +35,6 @@ class ToolRegistry {
         SaveScreenshotTool.register(in: self)
         ExecuteAppleScriptTool.register(in: self)
         ExecuteAppleScriptFileTool.register(in: self)
+        GetScreenContextTool.register(in: self)
     }
 }

--- a/Sources/swift-mcp-gui/Utilities/ParameterParser.swift
+++ b/Sources/swift-mcp-gui/Utilities/ParameterParser.swift
@@ -78,6 +78,28 @@ struct ParameterParser {
         return str
     }
     
+    func parseBool(_ key: String) throws -> Bool {
+        guard case .object(let dict) = arguments,
+              let value = dict[key] else {
+            throw ParameterError.missingParameter(key)
+        }
+
+        if case .bool(let b) = value {
+            return b
+        }
+
+        if case .string(let str) = value {
+            switch str.lowercased() {
+            case "true": return true
+            case "false": return false
+            default:
+                throw ParameterError.invalidType(key: key, expected: "boolean", received: str)
+            }
+        }
+
+        throw ParameterError.invalidType(key: key, expected: "boolean", received: String(describing: value))
+    }
+
     func parseStringArray(_ key: String) throws -> [String] {
         // Check if arguments is an object
         guard case .object(let dict) = arguments,

--- a/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
@@ -14,6 +14,7 @@ struct ScreenToolsTests {
         CaptureScreenTool.register(in: toolRegistry)
         CaptureRegionTool.register(in: toolRegistry)
         SaveScreenshotTool.register(in: toolRegistry)
+        GetScreenContextTool.register(in: toolRegistry)
     }
     
     @Test("Scroll tool execution")
@@ -350,6 +351,57 @@ struct ScreenToolsTests {
         }
     }
     
+    @Test("Get screen context tool with default parameters")
+    func getScreenContextToolDefault() async throws {
+        let arguments: Value = .object([:])
+
+        let result = try await toolRegistry.execute(name: "getScreenContext", arguments: arguments)
+        if result.isError != true {
+            #expect(result.content.first {
+                if case .text(let text, _, _) = $0 {
+                    return text.contains("Visible windows:")
+                }
+                return false
+            } != nil)
+        }
+    }
+
+    @Test("Get screen context tool with JSON format")
+    func getScreenContextToolJSON() async throws {
+        let arguments: Value = .object([
+            "format": .string("json")
+        ])
+
+        let result = try await toolRegistry.execute(name: "getScreenContext", arguments: arguments)
+        if result.isError != true {
+            #expect(result.content.first {
+                if case .text(let text, _, _) = $0 {
+                    return text.contains("\"visibleWindows\"")
+                }
+                return false
+            } != nil)
+        }
+    }
+
+    @Test("Get screen context tool with custom options")
+    func getScreenContextToolCustomOptions() async throws {
+        let arguments: Value = .object([
+            "maxDepth": .int(2),
+            "maxNodes": .int(50),
+            "includeAXTree": .bool(false)
+        ])
+
+        let result = try await toolRegistry.execute(name: "getScreenContext", arguments: arguments)
+        if result.isError != true {
+            #expect(result.content.first {
+                if case .text(let text, _, _) = $0 {
+                    return !text.contains("Focused window AX tree:")
+                }
+                return false
+            } != nil)
+        }
+    }
+
     @Test("Save screenshot tool with missing filename")
     func saveScreenshotToolMissingFilename() async throws {
         let arguments: Value = .object([

--- a/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
@@ -356,14 +356,13 @@ struct ScreenToolsTests {
         let arguments: Value = .object([:])
 
         let result = try await toolRegistry.execute(name: "getScreenContext", arguments: arguments)
-        if result.isError != true {
-            #expect(result.content.first {
-                if case .text(let text, _, _) = $0 {
-                    return text.contains("Visible windows:")
-                }
-                return false
-            } != nil)
-        }
+        // Tool should return successfully (not error)
+        #expect(result.isError != true)
+        // Should have at least one text content
+        #expect(result.content.first {
+            if case .text = $0 { return true }
+            return false
+        } != nil)
     }
 
     @Test("Get screen context tool with JSON format")


### PR DESCRIPTION
## Summary
- Add new `getScreenContext` MCP tool that retrieves rich context about the current screen state (frontmost app, visible windows, accessibility tree)
- Add `parseBool` method to `ParameterParser` for boolean parameter handling
- Add unit tests for the new tool

## Test plan
- [ ] Run `swift test` to verify unit tests pass
- [ ] Launch MCP Inspector and test `getScreenContext` with default parameters
- [ ] Test with `format: "json"` option
- [ ] Test with `includeAXTree: false` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)