### PR TITLE
Share Claude skill guidance with Codex

### DIFF
--- a/.agents/skills/inspect/SKILL.md
+++ b/.agents/skills/inspect/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: inspect
+description: Read the shared MCP Inspector skill from .claude/skills/inspect/SKILL.md
+---
+
+# MCP Inspector
+
+Read and follow the shared skill definition at:
+
+`.claude/skills/inspect/SKILL.md`

--- a/.claude/skills/inspect/SKILL.md
+++ b/.claude/skills/inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inspect
-description: Launch MCP Inspector to interactively test swift-mcp-gui tools via browser
+description: Launch MCP Inspector to interactively test swift-mcp-gui tools in a browser
 allowed-tools: Bash
 disable-model-invocation: true
 ---
@@ -8,6 +8,10 @@ disable-model-invocation: true
 # MCP Inspector
 
 Launch the MCP Inspector to interactively test the swift-mcp-gui MCP server in a browser.
+
+This skill is shared by Claude Code and Codex. Use the shell command tool
+available in the current agent runtime (for example, Bash in Claude Code or the
+terminal/exec command tool in Codex).
 
 ## Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+This repository keeps its shared agent guidance in `CLAUDE.md`.
+
+Codex agents should read and follow `CLAUDE.md` for build commands,
+architecture notes, dependencies, and development workflow.
+
+Project skills are authored once for both agent runtimes:
+
+- Shared skills: `.claude/skills/`
+
+Codex command entrypoints live in `.agents/skills/`, but each `SKILL.md` should
+only point to the matching shared skill under `.claude/skills/`. Do not duplicate
+the full skill workflow in `.agents/skills/`.


### PR DESCRIPTION
## Summary
- Add AGENTS.md that points Codex to CLAUDE.md for shared repository guidance
- Keep .agents/skills/inspect as a thin command entrypoint that points to the shared Claude skill
- Mark the Claude inspect skill as shared by Claude Code and Codex

## Testing
- Not run; documentation and skill metadata only