### PR TITLE
fix: gate live GUI tests in CI

### DIFF
--- a/Tests/swift-mcp-guiTests/Tools/KeyboardToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/KeyboardToolsTests.swift
@@ -2,7 +2,7 @@ import Testing
 import MCP
 @testable import swift_mcp_gui
 
-@Suite("Keyboard Tools Tests")
+@Suite("Keyboard Tools Tests", .serialized)
 struct KeyboardToolsTests {
     let toolRegistry: ToolRegistry
     
@@ -11,7 +11,10 @@ struct KeyboardToolsTests {
         SendKeysTool.register(in: toolRegistry)
     }
     
-    @Test("Send keys tool execution with command+c")
+    @Test(
+        "Send keys tool execution with command+c",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func sendKeysToolExecution() async throws {
         let arguments: Value = .object([
             "keys": .array([.string("cmd"), .string("c")])
@@ -27,7 +30,10 @@ struct KeyboardToolsTests {
         } != nil)
     }
     
-    @Test("Send keys tool with single key")
+    @Test(
+        "Send keys tool with single key",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func sendKeysToolSingleKey() async throws {
         let arguments: Value = .object([
             "keys": .array([.string("space")])
@@ -43,7 +49,10 @@ struct KeyboardToolsTests {
         } != nil)
     }
     
-    @Test("Send keys tool with complex combination")
+    @Test(
+        "Send keys tool with complex combination",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func sendKeysToolComplexCombination() async throws {
         let arguments: Value = .object([
             "keys": .array([.string("cmd"), .string("shift"), .string("a")])
@@ -59,7 +68,10 @@ struct KeyboardToolsTests {
         } != nil)
     }
     
-    @Test("Send keys tool with alternative key names", arguments: [
+    @Test(
+        "Send keys tool with alternative key names",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled),
+        arguments: [
         (["command"], "command"),
         (["ctrl"], "ctrl"),
         (["opt"], "opt"),
@@ -68,7 +80,8 @@ struct KeyboardToolsTests {
         (["enter"], "enter"),
         (["esc"], "esc"),
         (["del"], "del")
-    ])
+        ]
+    )
     func sendKeysToolAlternativeNames(keys: [String], displayName: String) async throws {
         let arguments: Value = .object([
             "keys": .array(keys.map { .string($0) })
@@ -146,9 +159,13 @@ struct KeyboardToolsTests {
         } != nil)
     }
     
-    @Test("Send keys tool with number keys", arguments: [
-        "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"
-    ])
+    @Test(
+        "Send keys tool with number keys",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled),
+        arguments: [
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"
+        ]
+    )
     func sendKeysToolNumberKeys(key: String) async throws {
         let arguments: Value = .object([
             "keys": .array([.string(key)])
@@ -164,9 +181,13 @@ struct KeyboardToolsTests {
         } != nil)
     }
     
-    @Test("Send keys tool with letter keys", arguments: [
-        "a", "c", "v", "x", "z"
-    ])
+    @Test(
+        "Send keys tool with letter keys",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled),
+        arguments: [
+            "a", "c", "v", "x", "z"
+        ]
+    )
     func sendKeysToolLetterKeys(key: String) async throws {
         let arguments: Value = .object([
             "keys": .array([.string(key)])
@@ -182,9 +203,13 @@ struct KeyboardToolsTests {
         } != nil)
     }
     
-    @Test("Send keys tool with arrow keys", arguments: [
-        "up", "down", "left", "right"
-    ])
+    @Test(
+        "Send keys tool with arrow keys",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled),
+        arguments: [
+            "up", "down", "left", "right"
+        ]
+    )
     func sendKeysToolArrowKeys(key: String) async throws {
         let arguments: Value = .object([
             "keys": .array([.string(key)])

--- a/Tests/swift-mcp-guiTests/Tools/MouseToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/MouseToolsTests.swift
@@ -2,7 +2,7 @@ import Testing
 import MCP
 @testable import swift_mcp_gui
 
-@Suite("Mouse Tools Tests")
+@Suite("Mouse Tools Tests", .serialized)
 struct MouseToolsTests {
     let toolRegistry: ToolRegistry
     
@@ -12,7 +12,10 @@ struct MouseToolsTests {
         MouseClickTool.register(in: toolRegistry)
     }
     
-    @Test("Move mouse tool execution")
+    @Test(
+        "Move mouse tool execution",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func moveMouseToolExecution() async throws {
         let arguments: Value = .object([
             "x": .int(100),
@@ -29,7 +32,10 @@ struct MouseToolsTests {
         } != nil)
     }
     
-    @Test("Move mouse tool with double values")
+    @Test(
+        "Move mouse tool with double values",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func moveMouseToolWithDoubleValues() async throws {
         let arguments: Value = .object([
             "x": .double(100.5),
@@ -46,7 +52,10 @@ struct MouseToolsTests {
         } != nil)
     }
     
-    @Test("Move mouse tool with string values")
+    @Test(
+        "Move mouse tool with string values",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func moveMouseToolWithStringValues() async throws {
         let arguments: Value = .object([
             "x": .string("100"),
@@ -80,7 +89,10 @@ struct MouseToolsTests {
         } != nil)
     }
     
-    @Test("Mouse click tool execution")
+    @Test(
+        "Mouse click tool execution",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func mouseClickToolExecution() async throws {
         let arguments: Value = .object([
             "button": .string("left")
@@ -96,7 +108,10 @@ struct MouseToolsTests {
         } != nil)
     }
     
-    @Test("Mouse click tool right click")
+    @Test(
+        "Mouse click tool right click",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func mouseClickToolRightClick() async throws {
         let arguments: Value = .object([
             "button": .string("right")
@@ -142,9 +157,13 @@ struct MouseToolsTests {
         } != nil)
     }
     
-    @Test("Mouse click tool with case variations", arguments: [
-        ("Left", "Left"), ("LEFT", "LEFT"), ("Right", "Right"), ("RIGHT", "RIGHT")
-    ])
+    @Test(
+        "Mouse click tool with case variations",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled),
+        arguments: [
+            ("Left", "Left"), ("LEFT", "LEFT"), ("Right", "Right"), ("RIGHT", "RIGHT")
+        ]
+    )
     func mouseClickToolCaseVariations(input: String, expected: String) async throws {
         let arguments: Value = .object([
             "button": .string(input)

--- a/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
+++ b/Tests/swift-mcp-guiTests/Tools/ScreenToolsTests.swift
@@ -1,8 +1,9 @@
 import Testing
 import MCP
+import Foundation
 @testable import swift_mcp_gui
 
-@Suite("Screen Tools Tests")
+@Suite("Screen Tools Tests", .serialized)
 struct ScreenToolsTests {
     let toolRegistry: ToolRegistry
     
@@ -17,7 +18,10 @@ struct ScreenToolsTests {
         GetScreenContextTool.register(in: toolRegistry)
     }
     
-    @Test("Scroll tool execution")
+    @Test(
+        "Scroll tool execution",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func scrollToolExecution() async throws {
         let arguments: Value = .object([
             "direction": .string("up"),
@@ -34,9 +38,13 @@ struct ScreenToolsTests {
         } != nil)
     }
     
-    @Test("Scroll tool all directions", arguments: [
-        "up", "down", "left", "right"
-    ])
+    @Test(
+        "Scroll tool all directions",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled),
+        arguments: [
+            "up", "down", "left", "right"
+        ]
+    )
     func scrollToolAllDirections(direction: String) async throws {
         let arguments: Value = .object([
             "direction": .string(direction),
@@ -102,7 +110,10 @@ struct ScreenToolsTests {
         } != nil)
     }
     
-    @Test("Scroll tool with string clicks value")
+    @Test(
+        "Scroll tool with string clicks value",
+        .enabled(if: GUITestConfiguration.liveInputTestsEnabled)
+    )
     func scrollToolStringClicks() async throws {
         let arguments: Value = .object([
             "direction": .string("down"),
@@ -135,7 +146,10 @@ struct ScreenToolsTests {
         } != nil)
     }
     
-    @Test("Get pixel color tool execution")
+    @Test(
+        "Get pixel color tool execution",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func getPixelColorToolExecution() async throws {
         let arguments: Value = .object([
             "x": .int(100),
@@ -176,7 +190,10 @@ struct ScreenToolsTests {
         } != nil)
     }
     
-    @Test("Get pixel color tool with string parameters")
+    @Test(
+        "Get pixel color tool with string parameters",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func getPixelColorToolStringParameters() async throws {
         let arguments: Value = .object([
             "x": .string("50"),
@@ -195,7 +212,10 @@ struct ScreenToolsTests {
         }
     }
     
-    @Test("Get pixel color tool with double parameters")
+    @Test(
+        "Get pixel color tool with double parameters",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func getPixelColorToolDoubleParameters() async throws {
         let arguments: Value = .object([
             "x": .double(50.5),
@@ -214,7 +234,10 @@ struct ScreenToolsTests {
         }
     }
     
-    @Test("Capture screen tool execution")
+    @Test(
+        "Capture screen tool execution",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func captureScreenToolExecution() async throws {
         let arguments: Value = .object([:])
         
@@ -232,7 +255,10 @@ struct ScreenToolsTests {
         }
     }
 
-    @Test("Capture screen tool with low quality")
+    @Test(
+        "Capture screen tool with low quality",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func captureScreenToolLowQuality() async throws {
         let arguments: Value = .object([
             "quality": .double(0.3)
@@ -252,7 +278,10 @@ struct ScreenToolsTests {
         }
     }
 
-    @Test("Capture screen tool with image output")
+    @Test(
+        "Capture screen tool with image output",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func captureScreenToolImageOutput() async throws {
         let arguments: Value = .object([
             "output": .string("image")
@@ -268,7 +297,10 @@ struct ScreenToolsTests {
         }
     }
 
-    @Test("Capture region tool execution")
+    @Test(
+        "Capture region tool execution",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func captureRegionToolExecution() async throws {
         let arguments: Value = .object([
             "x": .int(100),
@@ -309,10 +341,16 @@ struct ScreenToolsTests {
         } != nil)
     }
     
-    @Test("Save screenshot tool execution")
+    @Test(
+        "Save screenshot tool execution",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func saveScreenshotToolExecution() async throws {
+        let filename = GUITestConfiguration.temporaryFilename("test_screenshot.png")
+        defer { try? FileManager.default.removeItem(atPath: filename) }
+
         let arguments: Value = .object([
-            "filename": .string("test_screenshot.png")
+            "filename": .string(filename)
         ])
         
         let result = try await toolRegistry.execute(name: "saveScreenshot", arguments: arguments)
@@ -321,17 +359,23 @@ struct ScreenToolsTests {
             #expect(result.content.first { 
                 if case .text(let text, _, _) = $0 {
                     return text.contains("\"success\": true") &&
-                           text.contains("\"filename\": \"test_screenshot.png\"")
+                           text.contains("\"filename\": \"\(filename)\"")
                 }
                 return false
             } != nil)
         }
     }
     
-    @Test("Save screenshot tool with region")
+    @Test(
+        "Save screenshot tool with region",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func saveScreenshotToolWithRegion() async throws {
+        let filename = GUITestConfiguration.temporaryFilename("test_region_screenshot.png")
+        defer { try? FileManager.default.removeItem(atPath: filename) }
+
         let arguments: Value = .object([
-            "filename": .string("test_region_screenshot.png"),
+            "filename": .string(filename),
             "x": .int(50),
             "y": .int(50),
             "width": .int(150),
@@ -344,14 +388,17 @@ struct ScreenToolsTests {
             #expect(result.content.first { 
                 if case .text(let text, _, _) = $0 {
                     return text.contains("\"success\": true") &&
-                           text.contains("\"filename\": \"test_region_screenshot.png\"")
+                           text.contains("\"filename\": \"\(filename)\"")
                 }
                 return false
             } != nil)
         }
     }
     
-    @Test("Get screen context tool with default parameters")
+    @Test(
+        "Get screen context tool with default parameters",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func getScreenContextToolDefault() async throws {
         let arguments: Value = .object([:])
 
@@ -365,7 +412,10 @@ struct ScreenToolsTests {
         } != nil)
     }
 
-    @Test("Get screen context tool with JSON format")
+    @Test(
+        "Get screen context tool with JSON format",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func getScreenContextToolJSON() async throws {
         let arguments: Value = .object([
             "format": .string("json")
@@ -382,7 +432,10 @@ struct ScreenToolsTests {
         }
     }
 
-    @Test("Get screen context tool with custom options")
+    @Test(
+        "Get screen context tool with custom options",
+        .enabled(if: GUITestConfiguration.liveScreenTestsEnabled)
+    )
     func getScreenContextToolCustomOptions() async throws {
         let arguments: Value = .object([
             "maxDepth": .int(2),

--- a/Tests/swift-mcp-guiTests/Utilities/GUITestConfiguration.swift
+++ b/Tests/swift-mcp-guiTests/Utilities/GUITestConfiguration.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum GUITestConfiguration {
+    static let liveInputTestsEnabled =
+        ProcessInfo.processInfo.environment["SWIFT_MCP_GUI_RUN_INPUT_TESTS"] == "1"
+        || ProcessInfo.processInfo.environment["SWIFTAUTOGUI_RUN_INPUT_TESTS"] == "1"
+
+    static let liveScreenTestsEnabled =
+        ProcessInfo.processInfo.environment["SWIFT_MCP_GUI_RUN_SCREEN_TESTS"] == "1"
+
+    static func temporaryFilename(_ basename: String) -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(basename)")
+            .path
+    }
+}


### PR DESCRIPTION
## Summary
- gate live keyboard, mouse, scroll, and screen-capture tests behind opt-in environment variables
- serialize GUI side-effect suites to avoid concurrent input synthesis
- write live screenshot test outputs to temporary unique paths and clean them up

## Verification
- swift test -v
- SWIFT_MCP_GUI_RUN_INPUT_TESTS=1 SWIFT_MCP_GUI_RUN_SCREEN_TESTS=1 swift test -q
- swift test -q